### PR TITLE
Remove casting from Code

### DIFF
--- a/Model/AttributeOptionCodeRepository.php
+++ b/Model/AttributeOptionCodeRepository.php
@@ -41,7 +41,7 @@ class AttributeOptionCodeRepository
 
         $result = $this->dbConnection->fetchOne($select);
 
-        return $result ? (int)$result : null;
+        return $result ? $result : null;
     }
 
     public function setOptionId($entityType, $attributeCode, $optionCode, $optionId)


### PR DESCRIPTION
I believe the casting was a copy and pate from the getOptionId function and we should not cast code.