### PR TITLE
Add `getOptionCodes` method for fewer db calls

### DIFF
--- a/Api/AttributeOptionCodeRepositoryInterface.php
+++ b/Api/AttributeOptionCodeRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+namespace SnowIO\AttributeOptionCode\Api;
+
+interface AttributeOptionCodeRepositoryInterface
+{
+    /**
+     * @param int $entityType
+     * @param string $attributeCode
+     * @param int $optionId
+     * @return string|null
+     */
+    public function getOptionCode($entityType, $attributeCode, $optionId);
+
+    /**
+     * @param int $entityType
+     * @param string $attributeCode
+     * @param int[] $optionIds
+     * @return array
+     */
+    public function getOptionCodes($entityType, $attributeCode, $optionIds);
+}

--- a/Model/AttributeOptionCodeRepository.php
+++ b/Model/AttributeOptionCodeRepository.php
@@ -44,6 +44,20 @@ class AttributeOptionCodeRepository
         return $result ? $result : null;
     }
 
+    public function getOptionCodes($entityType, $attributeCode, $optionIds)
+    {
+        $select = $this->dbConnection->select()
+            ->from(['t' => $this->dbConnection->getTableName('option_code')], ['option_id', 'option_code'])
+            ->join(['a' => $this->dbConnection->getTableName('eav_attribute')], 'a.attribute_id = t.attribute_id', [])
+            ->where('a.attribute_code = ?', $attributeCode)
+            ->where('a.entity_type_id = ?', $entityType)
+            ->where('t.option_id in (?)', $optionIds);
+
+        $result = $this->dbConnection->fetchPairs($select);
+
+        return $result ? $result : [];
+    }
+
     public function setOptionId($entityType, $attributeCode, $optionCode, $optionId)
     {
         $tableName = $this->dbConnection->getTableName('option_code');

--- a/Model/AttributeOptionCodeRepository.php
+++ b/Model/AttributeOptionCodeRepository.php
@@ -6,7 +6,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Model\ResourceModel\Db\Context;
 use Magento\Framework\Phrase;
 
-class AttributeOptionCodeRepository
+class AttributeOptionCodeRepository implements AttributeOptionCodeRepositoryInterface
 {
     private $dbConnection;
     

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -15,6 +15,9 @@
     <preference
         for="SnowIO\AttributeOptionCode\Api\Data\ProductInterface"
         type="SnowIO\AttributeOptionCode\Model\Product" />
+    <preference
+        for="SnowIO\AttributeOptionCode\Api\AttributeOptionCodeRepositoryInterface"
+        type="SnowIO\AttributeOptionCode\Model\AttributeOptionCodeRepository" />
 
     <type name="Magento\Eav\Model\EavCustomAttributeTypeLocator">
         <arguments>


### PR DESCRIPTION
- Create a `getOptionCodes` method in order to make less calls to the database
- Create an `AttributeOptionCodeRepositoryInterface` to expose the `option_code` getters to the public API