### PR TITLE
Ensure products are created in Admin scope first

### DIFF
--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -1,6 +1,9 @@
 <?php
 namespace SnowIO\AttributeOptionCode\Model;
 
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Phrase;
+use Magento\Store\Model\Store;
 use SnowIO\AttributeOptionCode\Api\Data\ProductInterface;
 use SnowIO\AttributeOptionCode\Api\ProductRepositoryInterface;
 
@@ -8,17 +11,33 @@ class ProductRepository implements ProductRepositoryInterface
 {
     private $vanillaRepository;
     private $productDataMapper;
+    private $storeManager;
+    private $productResourceModel;
 
     public function __construct(
         \Magento\Catalog\Api\ProductRepositoryInterface $vanillaRepository,
-        ProductDataMapper $productDataMapper
+        ProductDataMapper $productDataMapper,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Catalog\Model\ResourceModel\Product $productResourceModel
     ) {
         $this->vanillaRepository = $vanillaRepository;
         $this->productDataMapper = $productDataMapper;
+        $this->storeManager = $storeManager;
+        $this->productResourceModel = $productResourceModel;
     }
 
     public function save(ProductInterface $product, $saveOptions = false)
     {
+        if ($this->storeManager->getStore()->getCode() !== Store::ADMIN_CODE) {
+            if (!$this->productResourceModel->getIdBySku($product->getSku())) {
+                throw new InputException(
+                    new Phrase(
+                        'Product needs to exist in admin (all) scope before being created in store scope'
+                    )
+                );
+            }
+        }
+
         $this->productDataMapper->replaceOptionCodesWithOptionIds($product);
         $this->vanillaRepository->save($product, $saveOptions);
     }


### PR DESCRIPTION
I have seen issues where
- products are created in a store specific scope
- updated in the admin scope
- Some of the values in the store specific scope incorrectly have "Use Default Value" set against them

This exception will ensure that products are created and fully defined in the admin scope prior to any store specific updates.