### PR TITLE
Update CodedAttributeOptionRepositoryInterface.php

### DIFF
--- a/Api/CodedAttributeOptionRepositoryInterface.php
+++ b/Api/CodedAttributeOptionRepositoryInterface.php
@@ -12,6 +12,7 @@ interface CodedAttributeOptionRepositoryInterface
      *
      * @param int $entityType
      * @param string $attributeCode
+     * @param CodedAttributeOptionInterface $option
      * @return void
      * @throws StateException
      * @throws InputException


### PR DESCRIPTION
Add missing `@param` to docblock.

Fixes the following error on https://example.com/rest/all/schema?services=all

```xml
<message>
Notice: Undefined offset: 2 in /Users/lukerodgers/src/example/vendor/magento/framework/Reflection/TypeProcessor.php on line 752
</message>
```