### PR TITLE
Add Magento 2.3.1 support

### DIFF
--- a/Api/Data/ProductInterface.php
+++ b/Api/Data/ProductInterface.php
@@ -1,7 +1,18 @@
 <?php
+
 namespace SnowIO\AttributeOptionCode\Api\Data;
 
+/**
+ * Interface ProductInterface
+ *
+ * @package SnowIO\AttributeOptionCode\Api\Data
+ */
 interface ProductInterface extends \Magento\Catalog\Api\Data\ProductInterface
 {
-
+    /**
+     * @inheritDoc
+     *
+     * @return \SnowIO\AttributeOptionCode\Api\Data\ProductExtensionInterface|\Magento\Catalog\Api\Data\ProductExtensionInterface|null
+     */
+    public function getExtensionAttributes();
 }

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     ],
     "require": {
         "php": ">=5.6",
-        "magento/framework": "^100|^101",
-        "magento/module-eav": "^100|^101",
-        "magento/module-catalog": "^101|^102"
+        "magento/framework": "^100|^101|^102",
+        "magento/module-eav": "^100|^101|^102",
+        "magento/module-catalog": "^101|^102|^103"
     },
     "autoload": {
         "files": [ "registration.php" ],


### PR DESCRIPTION
### Description
This PR updates the composer version constraints to support Magento 2.3.1. Whilst testing the `/V1/products-with-option-codes/:sku` endpoint the following error was occurring:
```
"Method 'getExtensionAttributes' must be overridden in the interfaces which extend 'Magento\\Framework\\Api\\ExtensibleDataInterface'. Concrete return type must be specified. Please fix :\\SnowIO\\AttributeOptionCode\\Api\\Data\\ProductInterface"
```
when attempting to save the product using vanilla functionality (see https://github.com/snowio/magento2-attribute-option-code/blob/master/Model/ProductRepository.php#L42)

Adding the correct `@return` statement to the extended product interface resolved this issue