### PR TITLE
Update snow option code interface to show option_code in MAP

### DIFF
--- a/Block/Adminhtml/Edit/Options/Options.php
+++ b/Block/Adminhtml/Edit/Options/Options.php
@@ -71,7 +71,7 @@ class Options extends \Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Option
     }
 
     /**
-     * @param array $result
+     * @param array $values
      * @return array
      */
     private function getIdsFromValuesData(array $values): array

--- a/Block/Adminhtml/Edit/Options/Options.php
+++ b/Block/Adminhtml/Edit/Options/Options.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SnowIO\AttributeOptionCode\Block\Adminhtml\Edit\Options;
+
+use Magento\Catalog\Setup\CategorySetup;
+use SnowIO\AttributeOptionCode\Api\AttributeOptionCodeRepositoryInterface;
+
+class Options extends \Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options
+{
+    /** @var AttributeOptionCodeRepositoryInterface */
+    private $attributeOptionCodeRepository;
+
+    /**
+     * @var string
+     */
+    protected $_template = 'SnowIO_AttributeOptionCode::catalog/product/attribute/options.phtml';
+
+    /**
+     * Options constructor.
+     * @param \Magento\Backend\Block\Template\Context $context
+     * @param \Magento\Framework\Registry $registry
+     * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\CollectionFactory $attrOptionCollectionFactory
+     * @param \Magento\Framework\Validator\UniversalFactory $universalFactory
+     * @param AttributeOptionCodeRepositoryInterface $attributeOptionCodeRepository
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\CollectionFactory $attrOptionCollectionFactory,
+        \Magento\Framework\Validator\UniversalFactory $universalFactory,
+        AttributeOptionCodeRepositoryInterface $attributeOptionCodeRepository,
+        array $data = []
+    ) {
+        $this->attributeOptionCodeRepository = $attributeOptionCodeRepository;
+        parent::__construct($context, $registry, $attrOptionCollectionFactory, $universalFactory, $data);
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getOptionValues()
+    {
+        $values = parent::getOptionValues();
+        return $this->addOptionCodeToOptionValuesData($values);
+    }
+
+    /**
+     * @param $values
+     * @return array
+     */
+    private function addOptionCodeToOptionValuesData(array $values): array
+    {
+        $ids = $this->getIdsFromValuesData($values);
+        $attributeCode = $this->getAttributeObject()->getAttributeCode();
+        $optionCodes = $this->getOptionCodes($attributeCode, $ids);
+
+        return $this->mapOptionCodeWithValuesData($optionCodes, $values);
+    }
+
+    /**
+     * @param string $attributeCode
+     * @param array $ids
+     * @return array
+     */
+    private function getOptionCodes(string $attributeCode, array $ids): array
+    {
+        return $this
+            ->attributeOptionCodeRepository
+            ->getOptionCodes(CategorySetup::CATALOG_PRODUCT_ENTITY_TYPE_ID, $attributeCode, $ids);
+    }
+
+    /**
+     * @param array $result
+     * @return array
+     */
+    private function getIdsFromValuesData(array $values): array
+    {
+        return array_map(function ($item) {
+            return $item->getData('id');
+        }, $values);
+    }
+
+    /**
+     * @param array $optionCode
+     * @param array $values
+     * @return array
+     */
+    private function mapOptionCodeWithValuesData(array $optionCode, array $values): array
+    {
+        return array_map(function ($item) use ($optionCode) {
+            array_key_exists($item->getData('id'), $optionCode) ?
+                $item->setData('option_code', $optionCode[$item['id']]) :
+                $item->setData('option_code', " ");
+            return $item;
+        }, $values);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -32,4 +32,8 @@
             </argument>
         </arguments>
     </type>
+
+    <preference
+            for="Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options"
+            type="SnowIO\AttributeOptionCode\Block\Adminhtml\Edit\Options\Options"/>
 </config>

--- a/view/adminhtml/templates/catalog/product/attribute/options.phtml
+++ b/view/adminhtml/templates/catalog/product/attribute/options.phtml
@@ -65,12 +65,15 @@ $stores = $block->getStoresSortedBySortOrder();
             <input data-role="order" type="hidden" name="option[order][<%- data.id %>]"  value="<%- data.sort_order %>" <?php if ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) :?> disabled="disabled"<?php endif; ?>/>
         </td>
         <td class="col-default control-table-actions-cell">
-            <input class="input-radio" type="<%- data.intype %>" name="default[]" value="<%- data.id %>" <%- data.checked %><?php if ($block->getReadOnly()) :?>disabled="disabled"<?php endif;?>/></br>Option Code
+            <input class="input-radio" type="<%- data.intype %>" name="default[]" value="<%- data.id %>" <%- data.checked %><?php if ($block->getReadOnly()) :?>disabled="disabled"<?php endif;?>/><br /><br />
+            <label class="label admin__field-label" for="attribute_label" data-ui-id="attribute-edit-content-form-fieldset-element-text-code-label">
+                <span><?= $block->escapeHtml(__('Option Code')) ?></span>
+            </label>
         </td>
         <?php foreach ($stores as $_store) :?>
         <td class="col-<%- data.id %>">
-            <input name="option[value][<%- data.id %>][<?= (int) $_store->getId() ?>]" value="<%- data.store<?= /* @noEscape */ (int) $_store->getId() ?> %>" class="input-text<?php if ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) :?> required-option required-unique<?php endif; ?>" type="text" <?php if ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) :?> disabled="disabled"<?php endif;?>/>
-            <% if (data.option_code) { <span><%- data.option_code%></span> } %>
+            <input name="option[value][<%- data.id %>][<?= (int) $_store->getId() ?>]" value="<%- data.store<?= /* @noEscape */ (int) $_store->getId() ?> %>" class="input-text<?php if ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) :?> required-option required-unique<?php endif; ?>" type="text" <?php if ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) :?> disabled="disabled"<?php endif;?>/><br /><br />
+            <input type="text" name="option_code" value="<% if (data.option_code){ %> <%-data.option_code %> <% } %>" disabled/>
             <?php endforeach; ?>
         <td id="delete_button_container_<%- data.id %>" class="col-delete">
             <input type="hidden" class="delete-flag" name="option[delete][<%- data.id %>]" value="" />

--- a/view/adminhtml/templates/catalog/product/attribute/options.phtml
+++ b/view/adminhtml/templates/catalog/product/attribute/options.phtml
@@ -68,9 +68,10 @@ $stores = $block->getStoresSortedBySortOrder();
             <input class="input-radio" type="<%- data.intype %>" name="default[]" value="<%- data.id %>" <%- data.checked %><?php if ($block->getReadOnly()) :?>disabled="disabled"<?php endif;?>/></br>Option Code
         </td>
         <?php foreach ($stores as $_store) :?>
-            <td class="col-<%- data.id %>"><input name="option[value][<%- data.id %>][<?= (int) $_store->getId() ?>]" value="<%- data.store<?= /* @noEscape */ (int) $_store->getId() ?> %>" class="input-text<?php if ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) :?> required-option required-unique<?php endif; ?>" type="text" <?php if ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) :?> disabled="disabled"<?php endif;?>/>
-                </br><input type="text" class="input-text" value="<%- data.option_code%>"></input></td>
-        <?php endforeach; ?>
+        <td class="col-<%- data.id %>">
+            <input name="option[value][<%- data.id %>][<?= (int) $_store->getId() ?>]" value="<%- data.store<?= /* @noEscape */ (int) $_store->getId() ?> %>" class="input-text<?php if ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) :?> required-option required-unique<?php endif; ?>" type="text" <?php if ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) :?> disabled="disabled"<?php endif;?>/>
+            <% if (data.option_code) { <span><%- data.option_code%></span> } %>
+            <?php endforeach; ?>
         <td id="delete_button_container_<%- data.id %>" class="col-delete">
             <input type="hidden" class="delete-flag" name="option[delete][<%- data.id %>]" value="" />
             <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) :?>

--- a/view/adminhtml/templates/catalog/product/attribute/options.phtml
+++ b/view/adminhtml/templates/catalog/product/attribute/options.phtml
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/** @var $block \Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options */
+
+$stores = $block->getStoresSortedBySortOrder();
+?>
+<fieldset class="admin__fieldset fieldset">
+    <legend class="legend">
+        <span><?= $block->escapeHtml(__('Manage Options (Values of Your Attribute)')) ?></span>
+    </legend><br />
+    <div class="admin__control-table-wrapper" id="manage-options-panel" data-index="attribute_options_select_container">
+        <table class="admin__control-table" data-index="attribute_options_select">
+            <thead>
+            <tr id="attribute-options-table">
+                <th class="col-draggable"></th>
+                <th class="col-default control-table-actions-th">
+                    <span><?= $block->escapeHtml(__('Is Default')) ?></span>
+                </th>
+                <?php
+                foreach ($stores as $_store) :?>
+                    <th<?php if ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) :?> class="_required"<?php endif; ?>>
+                        <span><?= $block->escapeHtml(__($_store->getName())) ?></span>
+                    </th>
+                <?php endforeach;
+                $storetotal = count($stores) + 3;
+                ?>
+                <th class="col-delete">&nbsp;</th>
+            </tr>
+            </thead>
+            <tbody data-role="options-container" class="ignore-validate"></tbody>
+            <tfoot>
+            <tr>
+                <th colspan="<?= (int)$storetotal ?>" class="validation">
+                    <input type="hidden" class="required-dropdown-attribute-entry" name="dropdown_attribute_validation"/>
+                    <input type="hidden" class="required-dropdown-attribute-unique" name="dropdown_attribute_validation_unique"/>
+                </th>
+            </tr>
+            <tr>
+                <th colspan="<?= (int) $storetotal ?>" class="col-actions-add">
+                    <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) :?>
+                        <button id="add_new_option_button" data-action="add_new_row"
+                                title="<?= $block->escapeHtmlAttr(__('Add Option')) ?>"
+                                type="button" class="action- scalable add">
+                            <span><?= $block->escapeHtml(__('Add Option')) ?></span>
+                        </button>
+                    <?php endif; ?>
+                </th>
+            </tr>
+            </tfoot>
+        </table>
+        <input type="hidden" id="option-count-check" value="" />
+    </div>
+    <script id="row-template" type="text/x-magento-template">
+        <tr <% if (data.rowClasses) { %>class="<%- data.rowClasses %>"<% } %>>
+        <td class="col-draggable">
+            <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) :?>
+                <div data-role="draggable-handle" class="draggable-handle"
+                     title="<?= $block->escapeHtmlAttr(__('Sort Option')) ?>">
+                </div>
+            <?php endif; ?>
+            <input data-role="order" type="hidden" name="option[order][<%- data.id %>]"  value="<%- data.sort_order %>" <?php if ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) :?> disabled="disabled"<?php endif; ?>/>
+        </td>
+        <td class="col-default control-table-actions-cell">
+            <input class="input-radio" type="<%- data.intype %>" name="default[]" value="<%- data.id %>" <%- data.checked %><?php if ($block->getReadOnly()) :?>disabled="disabled"<?php endif;?>/></br>Option Code
+        </td>
+        <?php foreach ($stores as $_store) :?>
+            <td class="col-<%- data.id %>"><input name="option[value][<%- data.id %>][<?= (int) $_store->getId() ?>]" value="<%- data.store<?= /* @noEscape */ (int) $_store->getId() ?> %>" class="input-text<?php if ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) :?> required-option required-unique<?php endif; ?>" type="text" <?php if ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) :?> disabled="disabled"<?php endif;?>/>
+                </br><input type="text" class="input-text" value="<%- data.option_code%>"></input></td>
+        <?php endforeach; ?>
+        <td id="delete_button_container_<%- data.id %>" class="col-delete">
+            <input type="hidden" class="delete-flag" name="option[delete][<%- data.id %>]" value="" />
+            <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) :?>
+                <button id="delete_button_<%- data.id %>" title="<?= $block->escapeHtmlAttr(__('Delete')) ?>" type="button"
+                        class="action- scalable delete delete-option"
+                >
+                    <span><?= $block->escapeHtml(__('Delete')) ?></span>
+                </button>
+            <?php endif;?>
+        </td>
+        </tr>
+    </script>
+    <?php
+    $values = [];
+    foreach ($block->getOptionValues() as $value) {
+        $value = $value->getData();
+        $values[] = is_array($value) ? array_map(function ($str) {
+            return htmlspecialchars_decode($str, ENT_QUOTES);
+        }, $value) : $value;
+    }
+    ?>
+    <script type="text/x-magento-init">
+        {
+            "*": {
+                "Magento_Catalog/js/options": {
+                    "attributesData": <?= /* @noEscape */ json_encode($values, JSON_HEX_QUOT) ?>,
+                    "isSortable":  <?= (int)(!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) ?>,
+                    "isReadOnly": <?= (int)$block->getReadOnly() ?>
+                },
+                "Magento_Catalog/catalog/product/attribute/unique-validate": {
+                    "element": "required-dropdown-attribute-unique",
+                    "message": "<?= $block->escapeHtml(__("The value of Admin must be unique.")) ?>"
+                }
+            }
+        }
+    </script>
+</fieldset>

--- a/view/adminhtml/templates/catalog/product/attribute/options.phtml
+++ b/view/adminhtml/templates/catalog/product/attribute/options.phtml
@@ -20,13 +20,16 @@ $stores = $block->getStoresSortedBySortOrder();
                 <th class="col-default control-table-actions-th">
                     <span><?= $block->escapeHtml(__('Is Default')) ?></span>
                 </th>
+                <th class="col-default control-table-actions-th">
+                    <span><?= $block->escapeHtml(__('Option Code')) ?></span>
+                </th>
                 <?php
                 foreach ($stores as $_store) :?>
                     <th<?php if ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) :?> class="_required"<?php endif; ?>>
                         <span><?= $block->escapeHtml(__($_store->getName())) ?></span>
                     </th>
                 <?php endforeach;
-                $storetotal = count($stores) + 3;
+                $storetotal = count($stores) + 4;
                 ?>
                 <th class="col-delete">&nbsp;</th>
             </tr>
@@ -65,15 +68,14 @@ $stores = $block->getStoresSortedBySortOrder();
             <input data-role="order" type="hidden" name="option[order][<%- data.id %>]"  value="<%- data.sort_order %>" <?php if ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) :?> disabled="disabled"<?php endif; ?>/>
         </td>
         <td class="col-default control-table-actions-cell">
-            <input class="input-radio" type="<%- data.intype %>" name="default[]" value="<%- data.id %>" <%- data.checked %><?php if ($block->getReadOnly()) :?>disabled="disabled"<?php endif;?>/><br /><br />
-            <label class="label admin__field-label" for="attribute_label" data-ui-id="attribute-edit-content-form-fieldset-element-text-code-label">
-                <span><?= $block->escapeHtml(__('Option Code')) ?></span>
-            </label>
+            <input class="input-radio" type="<%- data.intype %>" name="default[]" value="<%- data.id %>" <%- data.checked %><?php if ($block->getReadOnly()) :?>disabled="disabled"<?php endif;?>/>
+        </td>
+        <td class="col-default">
+            <input class="input-text" type="text" name="option[code][<%- data.option_code %>]" value="<% if (data.option_code){ %><%-data.option_code %><% } %>" disabled/>
         </td>
         <?php foreach ($stores as $_store) :?>
         <td class="col-<%- data.id %>">
-            <input name="option[value][<%- data.id %>][<?= (int) $_store->getId() ?>]" value="<%- data.store<?= /* @noEscape */ (int) $_store->getId() ?> %>" class="input-text<?php if ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) :?> required-option required-unique<?php endif; ?>" type="text" <?php if ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) :?> disabled="disabled"<?php endif;?>/><br /><br />
-            <input type="text" name="option_code" value="<% if (data.option_code){ %> <%-data.option_code %> <% } %>" disabled/>
+            <input name="option[value][<%- data.id %>][<?= (int) $_store->getId() ?>]" value="<%- data.store<?= /* @noEscape */ (int) $_store->getId() ?> %>" class="input-text<?php if ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) :?> required-option required-unique<?php endif; ?>" type="text" <?php if ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) :?> disabled="disabled"<?php endif;?>/>
             <?php endforeach; ?>
         <td id="delete_button_container_<%- data.id %>" class="col-delete">
             <input type="hidden" class="delete-flag" name="option[delete][<%- data.id %>]" value="" />


### PR DESCRIPTION
When viewing this data in the MAP it looks like we have duplicates but we really don't. Being able to see the code would be useful. We should not support the ability of modifying the option_code via this UI.

