### PR TITLE
Reduce deadlocks bulk saving products

### DIFF
--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -13,17 +13,20 @@ class ProductRepository implements ProductRepositoryInterface
     private \SnowIO\AttributeOptionCode\Model\ProductDataMapper $productDataMapper;
     private \Magento\Store\Model\StoreManagerInterface $storeManager;
     private \Magento\Catalog\Model\ResourceModel\Product $productResourceModel;
+    private \Magento\Framework\App\ResourceConnection $resourceConnection;
 
     public function __construct(
         \Magento\Catalog\Api\ProductRepositoryInterface $vanillaRepository,
         ProductDataMapper $productDataMapper,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Catalog\Model\ResourceModel\Product $productResourceModel
+        \Magento\Catalog\Model\ResourceModel\Product $productResourceModel,
+        \Magento\Framework\App\ResourceConnection $resourceConnection
     ) {
         $this->vanillaRepository = $vanillaRepository;
         $this->productDataMapper = $productDataMapper;
         $this->storeManager = $storeManager;
         $this->productResourceModel = $productResourceModel;
+        $this->resourceConnection = $resourceConnection;
     }
 
     public function save(ProductInterface $product, $saveOptions = false)
@@ -37,6 +40,17 @@ class ProductRepository implements ProductRepositoryInterface
                 )
             );
         }
+
+        /**
+         * Helps to reduce deadlocks saving products at volume
+         *
+         * @link https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html
+         * @link https://dev.mysql.com/doc/refman/8.0/en/innodb-deadlocks-handling.html
+         * @link https://github.com/magento/magento2/blob/15ea8fdeecca7f4164362c8f50fb1ad64245df98/app/code/Magento/Indexer/Model/ResourceModel/AbstractResource.php#L145
+         */
+        $this->resourceConnection->getConnection()
+            ->query('set session transaction isolation level read committed');
+
 
         $this->productDataMapper->replaceOptionCodesWithOptionIds($product);
         $this->vanillaRepository->save($product, $saveOptions);


### PR DESCRIPTION
Same as in here 
https://github.com/magento/magento2/blob/15ea8fdeecca7f4164362c8f50fb1ad64245df98/app/code/Magento/Indexer/Model/ResourceModel/AbstractResource.php#L145

Using `READ COMMITTED` helps reduce deadlocks bulk saving/updating products via the rest api.